### PR TITLE
Multiqc report fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ results/
 testing/
 testing*
 *.pyc
+.nf-test.log
+.nf-test/

--- a/assets/multiqc_config.yml
+++ b/assets/multiqc_config.yml
@@ -1,4 +1,3 @@
-custom_logo: "$projectdir/assets/nf-core-molkart_logo_light.png"
 custom_logo_url: https://github.com/nf-core/molkart/
 custom_logo_title: "nf-core/molkart"
 
@@ -7,6 +6,10 @@ report_comment: >
   analysis pipeline. For information about how to interpret these results, please see the
   <a href="https://nf-co.re/molkart/dev/docs/output" target="_blank">documentation</a>.
 report_section_order:
+  segmentation_stats:
+    order: 800
+  my_custom_content_image:
+    order: 800
   "nf-core-molkart-methods-description":
     order: -1000
   software_versions:
@@ -16,16 +19,20 @@ report_section_order:
 
 export_plots: true
 
+run_module:
+  - custom_content
+
 custom_data:
   my_custom_content_image:
-    section_name: "Crop overview"
+    section_name: "Crop selection overview"
   segmentation_stats:
-    id: "segmentation_stats"
+    file_format: "csv"
+    plot_type: "table"
     section_name: "QC statistics from segmentation"
-    pconfig:
-      id: "segmentation_stats_table"
-      namespace: "Segmentation stats"
     headers:
+      sample_id:
+        title: sample_id
+        Description: "Sample"
       segmentation_method:
         title: Segmentation method
         description: "Segmentation method"
@@ -60,10 +67,11 @@ custom_data:
         title: Number of removed large cells
         description: "Total number of labels above max_area"
 sp:
-  segmentation_stats:
-    fn: "final_QC.all_samples.csv"
-    shared: true
   my_custom_content_image:
-    fn: "*.png"
+    fn: "*overview.png"
+  segmentation_stats:
+    fn: "*spot_QC.csv"
+    shared: true
 ignore_images: false
+
 disable_version_detection: true

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -25,7 +25,6 @@ process {
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
-        container = "community.wave.seqera.io/library/multiqc:1.22.1--4886de6095538010"
     }
 
     withName: 'MOLKARTQC' {

--- a/conf/test.config
+++ b/conf/test.config
@@ -26,4 +26,15 @@ params {
     mindagap_loopnum = 100
     clahe_pyramid_tile = 368
     segmentation_method = "mesmer,cellpose"
+
+    // Only used if additionally params.create_training_subset is used
+    crop_size_x = 30
+    crop_size_y = 30
+    crop_amount = 2
+}
+
+process {
+    withName: 'MULTIQC' {
+        container = "community.wave.seqera.io/library/multiqc:1.24.1--789bc3917c8666da"
+    }
 }

--- a/modules.json
+++ b/modules.json
@@ -37,7 +37,7 @@
                     },
                     "multiqc": {
                         "branch": "master",
-                        "git_sha": "8f2062e7b4185590fb9f43c275381a31a6544fc0",
+                        "git_sha": "06c8865e36741e05ad32ef70ab3fac127486af48",
                         "installed_by": ["modules"]
                     }
                 }

--- a/modules/nf-core/multiqc/environment.yml
+++ b/modules/nf-core/multiqc/environment.yml
@@ -1,7 +1,5 @@
-name: multiqc
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
-  - bioconda::multiqc=1.22.2
+  - bioconda::multiqc=1.24.1

--- a/modules/nf-core/multiqc/main.nf
+++ b/modules/nf-core/multiqc/main.nf
@@ -3,14 +3,16 @@ process MULTIQC {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/multiqc:1.22.2--pyhdfd78af_0' :
-        'biocontainers/multiqc:1.22.2--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/multiqc:1.24.1--pyhdfd78af_0' :
+        'biocontainers/multiqc:1.24.1--pyhdfd78af_0' }"
 
     input:
     path  multiqc_files, stageAs: "?/*"
     path(multiqc_config)
     path(extra_multiqc_config)
     path(multiqc_logo)
+    path(replace_names)
+    path(sample_names)
 
     output:
     path "*multiqc_report.html", emit: report
@@ -23,16 +25,22 @@ process MULTIQC {
 
     script:
     def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ? "--filename ${task.ext.prefix}.html" : ''
     def config = multiqc_config ? "--config $multiqc_config" : ''
     def extra_config = extra_multiqc_config ? "--config $extra_multiqc_config" : ''
-    def logo = multiqc_logo ? /--cl-config 'custom_logo: "${multiqc_logo}"'/ : ''
+    def logo = multiqc_logo ? "--cl-config 'custom_logo: \"${multiqc_logo}\"'" : ''
+    def replace = replace_names ? "--replace-names ${replace_names}" : ''
+    def samples = sample_names ? "--sample-names ${sample_names}" : ''
     """
     multiqc \\
         --force \\
         $args \\
         $config \\
+        $prefix \\
         $extra_config \\
         $logo \\
+        $replace \\
+        $samples \\
         .
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/nf-core/multiqc/meta.yml
+++ b/modules/nf-core/multiqc/meta.yml
@@ -29,6 +29,19 @@ input:
       type: file
       description: Optional logo file for MultiQC
       pattern: "*.{png}"
+  - replace_names:
+      type: file
+      description: |
+        Optional two-column sample renaming file. First column a set of
+        patterns, second column a set of corresponding replacements. Passed via
+        MultiQC's `--replace-names` option.
+      pattern: "*.{tsv}"
+  - sample_names:
+      type: file
+      description: |
+        Optional TSV file with headers, passed to the MultiQC --sample_names
+        argument.
+      pattern: "*.{tsv}"
 output:
   - report:
       type: file

--- a/modules/nf-core/multiqc/tests/main.nf.test
+++ b/modules/nf-core/multiqc/tests/main.nf.test
@@ -8,6 +8,8 @@ nextflow_process {
     tag "modules_nfcore"
     tag "multiqc"
 
+    config "./nextflow.config"
+
     test("sarscov2 single-end [fastqc]") {
 
         when {
@@ -17,6 +19,8 @@ nextflow_process {
                 input[1] = []
                 input[2] = []
                 input[3] = []
+                input[4] = []
+                input[5] = []
                 """
             }
         }
@@ -41,6 +45,8 @@ nextflow_process {
                 input[1] = Channel.of(file("https://github.com/nf-core/tools/raw/dev/nf_core/pipeline-template/assets/multiqc_config.yml", checkIfExists: true))
                 input[2] = []
                 input[3] = []
+                input[4] = []
+                input[5] = []
                 """
             }
         }
@@ -66,6 +72,8 @@ nextflow_process {
                 input[1] = []
                 input[2] = []
                 input[3] = []
+                input[4] = []
+                input[5] = []
                 """
             }
         }

--- a/modules/nf-core/multiqc/tests/main.nf.test.snap
+++ b/modules/nf-core/multiqc/tests/main.nf.test.snap
@@ -2,14 +2,14 @@
     "multiqc_versions_single": {
         "content": [
             [
-                "versions.yml:md5,ddbc971a8307f9b9b7b973714cde29d0"
+                "versions.yml:md5,6eb13f3b11bbcbfc98ad3166420ff760"
             ]
         ],
         "meta": {
             "nf-test": "0.8.4",
             "nextflow": "24.04.2"
         },
-        "timestamp": "2024-06-10T11:50:10.874341679"
+        "timestamp": "2024-07-10T12:41:34.562023"
     },
     "multiqc_stub": {
         "content": [
@@ -17,25 +17,25 @@
                 "multiqc_report.html",
                 "multiqc_data",
                 "multiqc_plots",
-                "versions.yml:md5,ddbc971a8307f9b9b7b973714cde29d0"
+                "versions.yml:md5,6eb13f3b11bbcbfc98ad3166420ff760"
             ]
         ],
         "meta": {
             "nf-test": "0.8.4",
             "nextflow": "24.04.2"
         },
-        "timestamp": "2024-06-10T11:50:49.271943761"
+        "timestamp": "2024-07-10T11:27:11.933869532"
     },
     "multiqc_versions_config": {
         "content": [
             [
-                "versions.yml:md5,ddbc971a8307f9b9b7b973714cde29d0"
+                "versions.yml:md5,6eb13f3b11bbcbfc98ad3166420ff760"
             ]
         ],
         "meta": {
             "nf-test": "0.8.4",
             "nextflow": "24.04.2"
         },
-        "timestamp": "2024-06-10T11:50:34.046706025"
+        "timestamp": "2024-07-10T11:26:56.709849369"
     }
 }

--- a/modules/nf-core/multiqc/tests/nextflow.config
+++ b/modules/nf-core/multiqc/tests/nextflow.config
@@ -1,0 +1,5 @@
+process {
+    withName: 'MULTIQC' {
+        ext.prefix = null
+    }
+}

--- a/workflows/molkart.nf
+++ b/workflows/molkart.nf
@@ -310,7 +310,7 @@ workflow MOLKART {
         Channel.empty()
     ch_multiqc_logo          = params.multiqc_logo ?
         Channel.fromPath(params.multiqc_logo, checkIfExists: true) :
-        Channel.empty()
+        Channel.fromPath("$projectDir/assets/nf-core-molkart_logo_light.png", checkIfExists: true)
 
     summary_params      = paramsSummaryMap(
         workflow, parameters_schema: "nextflow_schema.json")
@@ -342,14 +342,16 @@ workflow MOLKART {
     } else {
         ch_multiqc_files = ch_multiqc_files.mix(
             MOLKARTQC.out.qc.map{it[1]}
-            .collectFile(name: 'final_QC.all_samples.csv', keepHeader: true, storeDir: "${params.outdir}/multiqc"))
+            .collectFile())
     }
 
     MULTIQC (
         ch_multiqc_files.collect(),
         ch_multiqc_config.toList(),
         ch_multiqc_custom_config.toList(),
-        ch_multiqc_logo.toList()
+        ch_multiqc_logo.toList(),
+        [],
+        []
     )
 
     emit:


### PR DESCRIPTION

Addresses https://github.com/nf-core/molkart/issues/72
Added parameters necessary for create_training_subset to run with test.config for easier use.
Updated MultiQC version to 1.24.1
For easier testing in Gitpod, moved the Seqera Container for MultiQC to test.config instead of modules.config (as the Biocontainer cannot be pulled in Gitpod).
put .nf-test.log to .gitignore
## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/molkart/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/molkart _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
