### PR TITLE
Use nf-test in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       matrix:
         NXF_VER:
-          - "24.04.2"
+          - "24.10.5"
           - "latest-everything"
         nf_test_files: ["${{ fromJson(needs.nf-test-changes.outputs.nf_test_files) }}"]
         profile:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
         run: |
           nf-test test \
             --verbose ${{ matrix.nf_test_files }} \
-            --profile "+${{ matrix.profile }}" \
+            --profile "+${{ matrix.profile }},test" \
             --junitxml=test.xml \
             --tap=test.tap
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
         run: |
           nf-test test \
             --verbose ${{ matrix.nf_test_files }} \
-            --profile "+${{ matrix.profile }},ci" \
+            --profile "+${{ matrix.profile }}" \
             --junitxml=test.xml \
             --tap=test.tap
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,18 +19,41 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  nf-test-changes:
+    name: Check for changes
+    runs-on: ubuntu-latest
+    outputs:
+      nf_test_files: ${{ steps.list.outputs.components }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: List nf-test files
+        id: list
+        uses: adamrtalbot/detect-nf-test-changes@v0.0.4
+        with:
+          head: ${{ github.sha }}
+          base: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
+
+      - name: print list of nf-test files
+        run: |
+          echo ${{ steps.list.outputs.components }}
+
   test:
-    name: "Run pipeline with test data (${{ matrix.NXF_VER }} | ${{ matrix.test_name }} | ${{ matrix.profile }})"
+    name: "Run tests (${{ matrix.nf_test_files }} ${{ matrix.profile }} NF-${{ matrix.NXF_VER }})"
     # Only run on push if this is the nf-core dev branch (merged PRs)
-    if: "${{ github.event_name != 'push' || (github.event_name == 'push' && github.repository == 'nf-core/molkart') }}"
+    needs: [nf-test-changes]
+    if: "${{ (github.event_name != 'push' || (github.event_name == 'push' && github.repository == 'nf-core/molkart')) && needs.nf-test-changes.outputs.nf_test_files != '[]' }}"
     runs-on: ubuntu-latest
     strategy:
       matrix:
         NXF_VER:
           - "24.04.2"
           - "latest-everything"
+        nf_test_files: ["${{ fromJson(needs.nf-test-changes.outputs.nf_test_files) }}"]
         profile:
-          - "conda"
           - "docker"
           - "singularity"
         test_name:
@@ -41,15 +64,18 @@ jobs:
           - profile: "conda"
 
     steps:
+      - name: install curl
+        run: sudo apt update && sudo apt install -y curl
+
       - name: Check out pipeline code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
 
-      - name: Set up Nextflow
+      - name: Install Nextflow
         uses: nf-core/setup-nextflow@v2
         with:
-          version: "${{ matrix.NXF_VER }}"
+          version: "${{ matrix.NXT_VER }}"
 
       - name: Set up Apptainer
         if: matrix.profile == 'singularity'
@@ -61,9 +87,63 @@ jobs:
           mkdir -p $NXF_SINGULARITY_CACHEDIR
           mkdir -p $NXF_SINGULARITY_LIBRARYDIR
 
+      - name: Install nf-test
+        uses: nf-core/setup-nf-test@v1
+        with:
+          version: ${{ env.NFT_VER }}
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+          architecture: "x64"
+
+      - name: Install pdiff to see diff between nf-test snapshots
+        run: |
+          python -m pip install --upgrade pip
+          pip install pdiff
+
       - name: Clean up Disk space
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
 
-      - name: "Run pipeline with test data ${{ matrix.NXF_VER }} | ${{ matrix.test_name }} | ${{ matrix.profile }}"
+      - name: Run nf-test
         run: |
-          nextflow run ${GITHUB_WORKSPACE} -profile ${{ matrix.test_name }},${{ matrix.profile }} --outdir ./results
+          nf-test test \
+            --verbose ${{ matrix.nf_test_files }} \
+            --profile "+${{ matrix.profile }},ci" \
+            --junitxml=test.xml \
+            --tap=test.tap
+
+      - uses: pcolby/tap-summary@v1
+        with:
+          path: >-
+            test.tap
+
+      - name: Output log on failure
+        if: failure()
+        run: |
+          sudo apt install bat > /dev/null
+          batcat --decorations=always --color=always ${{ github.workspace }}/.nf-test/tests/*/meta/nextflow.log
+
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v3
+        if: always()
+        with:
+          report_paths: test.xml
+
+  confirm-pass:
+    runs-on: ubuntu-latest
+    needs: [test]
+    if: always()
+    steps:
+      - name: All tests ok
+        if: ${{ !contains(needs.*.result, 'failure') }}
+        run: exit 0
+      - name: One or more tests failed
+        if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1
+
+      - name: debug-print
+        if: always()
+        run: |
+          echo "toJSON(needs) = ${{ toJSON(needs) }}"
+          echo "toJSON(needs.*.result) = ${{ toJSON(needs.*.result) }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       matrix:
         NXF_VER:
-          - "24.10.5"
+          - "24.04.2"
           - "latest-everything"
         nf_test_files: ["${{ fromJson(needs.nf-test-changes.outputs.nf_test_files) }}"]
         profile:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
   workflow_dispatch:
 
 env:
+  NFT_VER: "0.9.0"
   NXF_ANSI_LOG: false
   NXF_SINGULARITY_CACHEDIR: ${{ github.workspace }}/.singularity
   NXF_SINGULARITY_LIBRARYDIR: ${{ github.workspace }}/.singularity
@@ -75,7 +76,7 @@ jobs:
       - name: Install Nextflow
         uses: nf-core/setup-nextflow@v2
         with:
-          version: "${{ matrix.NXT_VER }}"
+          version: "${{ matrix.NXF_VER }}"
 
       - name: Set up Apptainer
         if: matrix.profile == 'singularity'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - [PR #111](https://github.com/nf-core/molkart/pull/111) - Updated json schemas (@kbestak)
+- [PR #116](https://github.com/nf-core/molkart/pull/116) - Update CI to use nf-test on changed files (@kbestak)
 
 ### Fixed
 

--- a/modules.json
+++ b/modules.json
@@ -37,7 +37,7 @@
                     },
                     "multiqc": {
                         "branch": "master",
-                        "git_sha": "81880787133db07d9b4c1febd152c090eb8325dc",
+                        "git_sha": "7b50cb7be890e4b28cffb82e438cc6a8d7805d3f",
                         "installed_by": ["modules"]
                     },
                     "stardist": {

--- a/modules.json
+++ b/modules.json
@@ -27,12 +27,12 @@
                     },
                     "mindagap/duplicatefinder": {
                         "branch": "master",
-                        "git_sha": "81880787133db07d9b4c1febd152c090eb8325dc",
+                        "git_sha": "a84e5d699986fac96d7d7f01044a339a343af827",
                         "installed_by": ["modules"]
                     },
                     "mindagap/mindagap": {
                         "branch": "master",
-                        "git_sha": "81880787133db07d9b4c1febd152c090eb8325dc",
+                        "git_sha": "a84e5d699986fac96d7d7f01044a339a343af827",
                         "installed_by": ["modules"]
                     },
                     "multiqc": {

--- a/modules/nf-core/mindagap/duplicatefinder/environment.yml
+++ b/modules/nf-core/mindagap/duplicatefinder/environment.yml
@@ -4,4 +4,5 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
+  - conda-forge::numpy=1.24.2
   - bioconda::mindagap=0.0.2

--- a/modules/nf-core/mindagap/duplicatefinder/main.nf
+++ b/modules/nf-core/mindagap/duplicatefinder/main.nf
@@ -2,9 +2,9 @@ process MINDAGAP_DUPLICATEFINDER {
     tag "$meta.id"
     label 'process_single'
 
-    conda "bioconda::mindagap=0.0.2"
+    conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/mindagap:0.0.2--pyhdfd78af_1':
+        'https://depot.galaxyproject.org/singularity/mindagap:0.0.2--pyhdfd78af_1' :
         'biocontainers/mindagap:0.0.2--pyhdfd78af_1' }"
 
     input:
@@ -18,12 +18,21 @@ process MINDAGAP_DUPLICATEFINDER {
     task.ext.when == null || task.ext.when
 
     script:
-    def args   = task.ext.args ?: ''
-    def prefix = task.ext.prefix ?: "${meta.id}"
+    def args = task.ext.args ?: ''
     """
     duplicate_finder.py \\
         $spot_table \\
         $args
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        mindagap: \$(mindagap.py test -v)
+    END_VERSIONS
+    """
+
+    stub:
+    """
+    touch ${spot_table.baseName}_markedDups.txt
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/mindagap/duplicatefinder/tests/main.nf.test
+++ b/modules/nf-core/mindagap/duplicatefinder/tests/main.nf.test
@@ -9,14 +9,46 @@ nextflow_process {
     tag "mindagap"
     tag "mindagap/duplicatefinder"
 
-    test("test_mindagap_duplicatefinder_spots") {
+    test("mindagap - duplicatefinder - spots - txt") {
 
         when {
+            params {
+                modules_testdata_base_path = 'https://raw.githubusercontent.com/nf-core/test-datasets/molkart/'
+            }
+
             process {
                 """
                 input[0] = [
-                    [ id:'test'], // meta map
-                    file('https://raw.githubusercontent.com/nf-core/test-datasets/molkart/test_data/input_data/spots.txt')
+                    [ id:'test'],
+                    file(params.modules_testdata_base_path + 'test_data/input_data/spots.txt', checkIfExists: true)
+                    ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+    test("mindagap - duplicatefinder - spots - stub") {
+
+        options "-stub"
+
+        when {
+            params {
+                modules_testdata_base_path = 'https://raw.githubusercontent.com/nf-core/test-datasets/molkart/'
+            }
+
+            process {
+                """
+                input[0] = [
+                    [ id:'test'],
+                    file(params.modules_testdata_base_path + 'test_data/input_data/spots.txt', checkIfExists: true)
                     ]
                 """
             }

--- a/modules/nf-core/mindagap/duplicatefinder/tests/main.nf.test.snap
+++ b/modules/nf-core/mindagap/duplicatefinder/tests/main.nf.test.snap
@@ -1,5 +1,38 @@
 {
-    "test_mindagap_duplicatefinder_spots": {
+    "mindagap - duplicatefinder - spots - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "spots_markedDups.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,ae112b853ec32ee1c5eecaf421d01003"
+                ],
+                "marked_dups_spots": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "spots_markedDups.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,ae112b853ec32ee1c5eecaf421d01003"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
+        },
+        "timestamp": "2025-04-02T19:57:30.980911113"
+    },
+    "mindagap - duplicatefinder - spots - txt": {
         "content": [
             {
                 "0": [
@@ -26,6 +59,10 @@
                 ]
             }
         ],
-        "timestamp": "2023-11-30T22:56:20.101101751"
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
+        },
+        "timestamp": "2025-04-02T19:57:24.039800026"
     }
 }

--- a/modules/nf-core/mindagap/duplicatefinder/tests/tags.yml
+++ b/modules/nf-core/mindagap/duplicatefinder/tests/tags.yml
@@ -1,2 +1,0 @@
-mindagap/duplicatefinder:
-  - modules/nf-core/mindagap/duplicatefinder/**

--- a/modules/nf-core/mindagap/mindagap/main.nf
+++ b/modules/nf-core/mindagap/mindagap/main.nf
@@ -4,8 +4,8 @@ process MINDAGAP_MINDAGAP {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-    'https://depot.galaxyproject.org/singularity/mindagap:0.0.2--pyhdfd78af_1' :
-    'biocontainers/mindagap:0.0.2--pyhdfd78af_1' }"
+        'https://depot.galaxyproject.org/singularity/mindagap:0.0.2--pyhdfd78af_1' :
+        'biocontainers/mindagap:0.0.2--pyhdfd78af_1' }"
 
     input:
     tuple val(meta), path(panorama)
@@ -18,8 +18,7 @@ process MINDAGAP_MINDAGAP {
     task.ext.when == null || task.ext.when
 
     script:
-    def args   = task.ext.args   ?: ''
-    def prefix = task.ext.prefix ?: "${meta.id}"
+    def args = task.ext.args ?: ''
     """
     mindagap.py \\
         $panorama \\
@@ -32,7 +31,6 @@ process MINDAGAP_MINDAGAP {
     """
 
     stub:
-    def prefix = task.ext.prefix ?: "${meta.id}"
     """
     touch ${panorama.baseName}_gridfilled.tiff
 

--- a/modules/nf-core/mindagap/mindagap/tests/main.nf.test
+++ b/modules/nf-core/mindagap/mindagap/tests/main.nf.test
@@ -17,7 +17,7 @@ nextflow_process {
                 """
                 input[0] = [
                     [ id:'test' ],
-                    file(params.test_data['imaging']['tiff']['mouse_heart_wga'], checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'imaging/tiff/mindagap.mouse_heart.wga.tiff', checkIfExists: true)
                 ]
                 """
             }
@@ -28,6 +28,30 @@ nextflow_process {
                 { assert process.success },
                 { assert snapshot(process.out.tiff).match("tiff") },
                 { assert snapshot(process.out.versions).match("versions") }
+            )
+        }
+
+    }
+
+    test("mindgap - tiff - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'imaging/tiff/mindagap.mouse_heart.wga.tiff', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
             )
         }
 

--- a/modules/nf-core/mindagap/mindagap/tests/main.nf.test.snap
+++ b/modules/nf-core/mindagap/mindagap/tests/main.nf.test.snap
@@ -1,4 +1,37 @@
 {
+    "mindgap - tiff - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "mindagap.mouse_heart.wga_gridfilled.tiff:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,937acaba2cb90efc2705b71839e6cefc"
+                ],
+                "tiff": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "mindagap.mouse_heart.wga_gridfilled.tiff:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,937acaba2cb90efc2705b71839e6cefc"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
+        },
+        "timestamp": "2025-04-02T19:54:00.036000058"
+    },
     "tiff": {
         "content": [
             [
@@ -10,6 +43,10 @@
                 ]
             ]
         ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
+        },
         "timestamp": "2023-12-15T11:01:20.825556802"
     },
     "versions": {
@@ -18,6 +55,10 @@
                 "versions.yml:md5,937acaba2cb90efc2705b71839e6cefc"
             ]
         ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
+        },
         "timestamp": "2023-12-15T11:01:20.840211732"
     }
 }

--- a/modules/nf-core/mindagap/mindagap/tests/tags.yml
+++ b/modules/nf-core/mindagap/mindagap/tests/tags.yml
@@ -1,2 +1,0 @@
-mindagap/mindagap:
-  - "modules/nf-core/mindagap/mindagap/**"

--- a/modules/nf-core/multiqc/environment.yml
+++ b/modules/nf-core/multiqc/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::multiqc=1.27
+  - bioconda::multiqc=1.28

--- a/modules/nf-core/multiqc/main.nf
+++ b/modules/nf-core/multiqc/main.nf
@@ -3,8 +3,8 @@ process MULTIQC {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/multiqc:1.27--pyhdfd78af_0' :
-        'biocontainers/multiqc:1.27--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/multiqc:1.28--pyhdfd78af_0' :
+        'biocontainers/multiqc:1.28--pyhdfd78af_0' }"
 
     input:
     path  multiqc_files, stageAs: "?/*"

--- a/modules/nf-core/multiqc/tests/main.nf.test.snap
+++ b/modules/nf-core/multiqc/tests/main.nf.test.snap
@@ -2,14 +2,14 @@
     "multiqc_versions_single": {
         "content": [
             [
-                "versions.yml:md5,8f3b8c1cec5388cf2708be948c9fa42f"
+                "versions.yml:md5,b05075d2d2b4f485c0d627a5c8e475b2"
             ]
         ],
         "meta": {
-            "nf-test": "0.9.2",
+            "nf-test": "0.9.0",
             "nextflow": "24.10.4"
         },
-        "timestamp": "2025-01-27T09:29:57.631982377"
+        "timestamp": "2025-03-26T16:05:18.927925"
     },
     "multiqc_stub": {
         "content": [
@@ -17,25 +17,25 @@
                 "multiqc_report.html",
                 "multiqc_data",
                 "multiqc_plots",
-                "versions.yml:md5,8f3b8c1cec5388cf2708be948c9fa42f"
+                "versions.yml:md5,b05075d2d2b4f485c0d627a5c8e475b2"
             ]
         ],
         "meta": {
-            "nf-test": "0.9.2",
+            "nf-test": "0.9.0",
             "nextflow": "24.10.4"
         },
-        "timestamp": "2025-01-27T09:30:34.743726958"
+        "timestamp": "2025-03-26T16:05:55.639955"
     },
     "multiqc_versions_config": {
         "content": [
             [
-                "versions.yml:md5,8f3b8c1cec5388cf2708be948c9fa42f"
+                "versions.yml:md5,b05075d2d2b4f485c0d627a5c8e475b2"
             ]
         ],
         "meta": {
-            "nf-test": "0.9.2",
+            "nf-test": "0.9.0",
             "nextflow": "24.10.4"
         },
-        "timestamp": "2025-01-27T09:30:21.44383553"
+        "timestamp": "2025-03-26T16:05:44.067369"
     }
 }

--- a/modules/nf-core/multiqc/tests/tags.yml
+++ b/modules/nf-core/multiqc/tests/tags.yml
@@ -1,2 +1,0 @@
-multiqc:
-  - modules/nf-core/multiqc/**

--- a/tests/.nftignore
+++ b/tests/.nftignore
@@ -9,7 +9,6 @@ multiqc/multiqc_plots/svg/*
 multiqc/multiqc_report.html
 multiqc/crop_overview.png
 multiqc/crop_overview.txt
-mindagap/*.txt
 clahe/*.tiff
 stack/*.tif
 molkartqc/crop_overview.png

--- a/tests/.nftignore
+++ b/tests/.nftignore
@@ -2,6 +2,7 @@
 pipeline_info/*.{html,json,txt,yml}
 multiqc/multiqc_data/multiqc_data.json
 multiqc/multiqc_data/multiqc.log
+multiqc/multiqc_data/multiqc_software_versions.txt
 multiqc/multiqc_plots/pdf/*
 multiqc/multiqc_plots/png/*
 multiqc/multiqc_plots/svg/*

--- a/tests/.nftignore
+++ b/tests/.nftignore
@@ -9,6 +9,7 @@ multiqc/multiqc_plots/svg/*
 multiqc/multiqc_report.html
 multiqc/crop_overview.png
 multiqc/crop_overview.txt
+mindagap/*.txt
 clahe/*.tiff
 stack/*.tif
 molkartqc/crop_overview.png

--- a/tests/main.nf.test.snap
+++ b/tests/main.nf.test.snap
@@ -95,7 +95,6 @@
                 "mem_only.mesmer.spot_QC.csv:md5,3273bd6fecf93a3d240614d1b38831c9",
                 "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f",
                 "multiqc_segmentation_stats.txt:md5,22da6b6457be552df182868d183e70cd",
-                "multiqc_software_versions.txt:md5,4330042277c9656779867f8aef4f8184",
                 "multiqc_sources.txt:md5,d2a044df39ce3c6abe5cdc2d67473490",
                 "mem_only_cellpose_mask.tif:md5,d962bae7277cc7ad8cf96708a806b418",
                 "mem_only_cellpose_filtered.csv:md5,4cd99d408b527fb0e74074cbd1880f52",
@@ -111,7 +110,7 @@
             "nf-test": "0.9.2",
             "nextflow": "24.10.5"
         },
-        "timestamp": "2025-03-26T15:09:22.923283861"
+        "timestamp": "2025-04-02T18:57:55.861900672"
     },
     "Two channels, stardist, mesmer, cellpose, clahe - stub": {
         "content": [
@@ -324,7 +323,6 @@
                 "nuc_only.stardist.spot_QC.csv:md5,9b77da0f85fc445ff36769d28d337898",
                 "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f",
                 "multiqc_segmentation_stats.txt:md5,7818314ba602541e88a8df30324b117d",
-                "multiqc_software_versions.txt:md5,9c53cb8b9d6bee9fe09bc637a4f52b72",
                 "multiqc_sources.txt:md5,d2a044df39ce3c6abe5cdc2d67473490",
                 "nuc_only_cellpose_mask.tif:md5,29947c9cc51a9dd791452710e00ea6d6",
                 "nuc_only_cellpose_filtered.csv:md5,7f18648607ce3e7c2e80e5d8025ef9c9",
@@ -344,7 +342,7 @@
             "nf-test": "0.9.2",
             "nextflow": "24.10.5"
         },
-        "timestamp": "2025-03-26T15:16:56.626937716"
+        "timestamp": "2025-04-02T18:56:48.060498517"
     },
     "Skip mindagap - clahe - cellpose": {
         "content": [
@@ -417,7 +415,6 @@
                 "mem_only.cellpose.spot_QC.csv:md5,e393966b17effbc05c1b93bb590d7e80",
                 "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f",
                 "multiqc_segmentation_stats.txt:md5,df4a397185b42e99cf2e45468a0decb7",
-                "multiqc_software_versions.txt:md5,bc6f6c19226d09c5422c8779a6b6631c",
                 "multiqc_sources.txt:md5,d2a044df39ce3c6abe5cdc2d67473490",
                 "mem_only_cellpose_mask.tif:md5,8faad3e707aba96d3b93d9419311e843",
                 "mem_only_cellpose_filtered.csv:md5,e4307f10a752d8ff24fdfe33d181ec28",
@@ -429,7 +426,7 @@
             "nf-test": "0.9.2",
             "nextflow": "24.10.5"
         },
-        "timestamp": "2025-03-26T15:07:40.890191664"
+        "timestamp": "2025-04-02T18:58:54.271728142"
     },
     "Create training subset": {
         "content": [
@@ -484,7 +481,6 @@
             [
                 "nuc_only_nuclear_gridfilled.tiff:md5,123763d54f05b2274690b3b84f9690b1",
                 "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f",
-                "multiqc_software_versions.txt:md5,563e1f10541a26481124c070c41e1e1f",
                 "multiqc_sources.txt:md5,d2a044df39ce3c6abe5cdc2d67473490"
             ]
         ],
@@ -492,7 +488,7 @@
             "nf-test": "0.9.2",
             "nextflow": "24.10.5"
         },
-        "timestamp": "2025-03-26T14:58:55.597472645"
+        "timestamp": "2025-04-02T18:59:24.255853817"
     },
     "Create training subset - stub": {
         "content": [

--- a/tests/main.nf.test.snap
+++ b/tests/main.nf.test.snap
@@ -90,6 +90,7 @@
                 "mem_only_mesmer.adata:md5,530649647a3466316ea52dde9dede4ab",
                 "mem_only_membrane_gridfilled.tiff:md5,6e24160d758468d2de07ca200dfb62c2",
                 "mem_only_nuclear_gridfilled.tiff:md5,123763d54f05b2274690b3b84f9690b1",
+                "mem_only_spots_markedDups.txt:md5,4562caad05850d7dd7b6e9235e068a8b",
                 "mem_only.cellpose.spot_QC.csv:md5,2090a0bc4307e9712a6150bafeb38ec5",
                 "mem_only.mesmer.spot_QC.csv:md5,3273bd6fecf93a3d240614d1b38831c9",
                 "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f",
@@ -109,7 +110,7 @@
             "nf-test": "0.9.2",
             "nextflow": "24.10.5"
         },
-        "timestamp": "2025-04-02T20:47:04.260240556"
+        "timestamp": "2025-04-03T11:20:29.322813595"
     },
     "Two channels, stardist, mesmer, cellpose, clahe - stub": {
         "content": [
@@ -202,6 +203,7 @@
                 "mem_only_stardist.adata:md5,d41d8cd98f00b204e9800998ecf8427e",
                 "mem_only_membrane_gridfilled.tiff:md5,d41d8cd98f00b204e9800998ecf8427e",
                 "mem_only_nuclear_gridfilled.tiff:md5,d41d8cd98f00b204e9800998ecf8427e",
+                "mem_only_spots_markedDups.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
                 "mem_only.csv:md5,d41d8cd98f00b204e9800998ecf8427e",
                 "mem_only_cellpose_mask.tif:md5,d41d8cd98f00b204e9800998ecf8427e",
                 "mem_only_cellpose_filtered.csv:md5,d41d8cd98f00b204e9800998ecf8427e",
@@ -221,7 +223,7 @@
             "nf-test": "0.9.2",
             "nextflow": "24.10.5"
         },
-        "timestamp": "2025-04-02T20:49:08.578801698"
+        "timestamp": "2025-04-03T11:23:15.483620486"
     },
     "Nuclear channel, stardist, mesmer and cellpose, without clahe": {
         "content": [
@@ -315,6 +317,7 @@
                 "nuc_only_mesmer.adata:md5,cd20ab6db5274bb85c960ea3bd8d2619",
                 "nuc_only_stardist.adata:md5,ba86d85b0ba0902dea90c719434a21db",
                 "nuc_only_nuclear_gridfilled.tiff:md5,123763d54f05b2274690b3b84f9690b1",
+                "nuc_only_spots_markedDups.txt:md5,4562caad05850d7dd7b6e9235e068a8b",
                 "nuc_only.cellpose.spot_QC.csv:md5,671d25520018573aaf6d7e5706dc8bc3",
                 "nuc_only.mesmer.spot_QC.csv:md5,f8f4eb85bb8269341ac072ac78962ed4",
                 "nuc_only.stardist.spot_QC.csv:md5,9b77da0f85fc445ff36769d28d337898",
@@ -339,7 +342,7 @@
             "nf-test": "0.9.2",
             "nextflow": "24.10.5"
         },
-        "timestamp": "2025-04-02T20:45:59.843833675"
+        "timestamp": "2025-04-03T11:18:38.364774708"
     },
     "Skip mindagap - clahe - cellpose": {
         "content": [

--- a/tests/main.nf.test.snap
+++ b/tests/main.nf.test.snap
@@ -90,7 +90,6 @@
                 "mem_only_mesmer.adata:md5,530649647a3466316ea52dde9dede4ab",
                 "mem_only_membrane_gridfilled.tiff:md5,6e24160d758468d2de07ca200dfb62c2",
                 "mem_only_nuclear_gridfilled.tiff:md5,123763d54f05b2274690b3b84f9690b1",
-                "mem_only_spots_markedDups.txt:md5,4562caad05850d7dd7b6e9235e068a8b",
                 "mem_only.cellpose.spot_QC.csv:md5,2090a0bc4307e9712a6150bafeb38ec5",
                 "mem_only.mesmer.spot_QC.csv:md5,3273bd6fecf93a3d240614d1b38831c9",
                 "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f",
@@ -110,7 +109,7 @@
             "nf-test": "0.9.2",
             "nextflow": "24.10.5"
         },
-        "timestamp": "2025-04-02T18:57:55.861900672"
+        "timestamp": "2025-04-02T20:47:04.260240556"
     },
     "Two channels, stardist, mesmer, cellpose, clahe - stub": {
         "content": [
@@ -203,7 +202,6 @@
                 "mem_only_stardist.adata:md5,d41d8cd98f00b204e9800998ecf8427e",
                 "mem_only_membrane_gridfilled.tiff:md5,d41d8cd98f00b204e9800998ecf8427e",
                 "mem_only_nuclear_gridfilled.tiff:md5,d41d8cd98f00b204e9800998ecf8427e",
-                "mem_only_spots_markedDups.txt:md5,ef8ae4bc5ab898c5538daacd59897f86",
                 "mem_only.csv:md5,d41d8cd98f00b204e9800998ecf8427e",
                 "mem_only_cellpose_mask.tif:md5,d41d8cd98f00b204e9800998ecf8427e",
                 "mem_only_cellpose_filtered.csv:md5,d41d8cd98f00b204e9800998ecf8427e",
@@ -223,7 +221,7 @@
             "nf-test": "0.9.2",
             "nextflow": "24.10.5"
         },
-        "timestamp": "2025-04-01T15:38:25.466827537"
+        "timestamp": "2025-04-02T20:49:08.578801698"
     },
     "Nuclear channel, stardist, mesmer and cellpose, without clahe": {
         "content": [
@@ -317,7 +315,6 @@
                 "nuc_only_mesmer.adata:md5,cd20ab6db5274bb85c960ea3bd8d2619",
                 "nuc_only_stardist.adata:md5,ba86d85b0ba0902dea90c719434a21db",
                 "nuc_only_nuclear_gridfilled.tiff:md5,123763d54f05b2274690b3b84f9690b1",
-                "nuc_only_spots_markedDups.txt:md5,4562caad05850d7dd7b6e9235e068a8b",
                 "nuc_only.cellpose.spot_QC.csv:md5,671d25520018573aaf6d7e5706dc8bc3",
                 "nuc_only.mesmer.spot_QC.csv:md5,f8f4eb85bb8269341ac072ac78962ed4",
                 "nuc_only.stardist.spot_QC.csv:md5,9b77da0f85fc445ff36769d28d337898",
@@ -342,7 +339,7 @@
             "nf-test": "0.9.2",
             "nextflow": "24.10.5"
         },
-        "timestamp": "2025-04-02T18:56:48.060498517"
+        "timestamp": "2025-04-02T20:45:59.843833675"
     },
     "Skip mindagap - clahe - cellpose": {
         "content": [


### PR DESCRIPTION
Adapted the CI script to run nf-test on files that have been changed.
Updated multiqc module.
Updated nftignore

Temporary fix - mindagap/duplicatefinder is missing the stub section - temporarily, the markedDups.txt is removed from testing.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/molkart/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/molkart _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
